### PR TITLE
Ensure IP address used in port.Address for consistency

### DIFF
--- a/freeport.go
+++ b/freeport.go
@@ -82,11 +82,16 @@ func GetFreeTCPPort(address string) (*Port, error) {
 		return nil, err
 	}
 	var port int
+	tcpAddrString := address
 	if tcpAddr, ok := l.Addr().(*net.TCPAddr); ok {
 		port = tcpAddr.Port
+		tcpAddrString = tcpAddr.IP.String()
 	}
 
-	return &Port{Address: l.Addr().String(), Port: port, Protocol: TCP}, nil
+	// We could just use address as for GetPort, but this change
+	// honors spirit of original code in allowing the listen IP
+	// to change in some way
+	return &Port{Address: tcpAddrString, Port: port, Protocol: TCP}, nil
 }
 
 // GetPort for protocol is the specific port is free
@@ -133,11 +138,15 @@ func GetFreeUDPPort(address string) (*Port, error) {
 		return nil, err
 	}
 	var port int
+	addrString := address
 	if udpAddr, ok := l.LocalAddr().(*net.UDPAddr); ok {
 		port = udpAddr.Port
+		addrString = udpAddr.IP.String()
 	}
 
-	return &Port{Address: l.LocalAddr().String(), Port: port, Protocol: UDP}, nil
+	// This should always be equal to address, but if for some reason the OS remaps
+	// this honors the returned address
+	return &Port{Address: addrString, Port: port, Protocol: UDP}, nil
 }
 
 // MustGetFreeTCPPort get a free tcp port for address or panic

--- a/freeport_test.go
+++ b/freeport_test.go
@@ -11,11 +11,13 @@ func TestGetFreePort(t *testing.T) {
 		port, err := GetFreePort("127.0.0.1", UDP)
 		require.Nil(t, err)
 		require.NotNil(t, port)
+		require.Equal(t, "127.0.0.1", port.Address)
 	})
 	t.Run("TCP Port", func(t *testing.T) {
 		port, err := GetFreePort("127.0.0.1", TCP)
 		require.Nil(t, err)
 		require.NotNil(t, port)
+		require.Equal(t, "127.0.0.1", port.Address)
 	})
 	t.Run("TCP Port on unknown address", func(t *testing.T) {
 		port, err := GetFreePort("1.2.3.4", TCP)
@@ -50,6 +52,7 @@ func TestGetFreePortInRange(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, port)
 		require.True(t, min <= port.Port && port.Port <= max)
+		require.Equal(t, "127.0.0.1", port.Address)
 	})
 	t.Run("TCP in range", func(t *testing.T) {
 		min, max := 10000, 20000
@@ -57,6 +60,7 @@ func TestGetFreePortInRange(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, port)
 		require.True(t, min <= port.Port && port.Port <= max)
+		require.Equal(t, "127.0.0.1", port.Address)
 	})
 	t.Run("Invalid Interval", func(t *testing.T) {
 		min, max := 20000, 10000


### PR DESCRIPTION
(This is intended to resolve a downstream issue in Nuclei where multiple instances cannot run and collect stats.)

Fix for https://github.com/projectdiscovery/freeport/issues/22


The actual change is just about ensuring consistency in the `Address` portion of the `Port` object. 

Previously if you called just `GetPort()` then the `Address` field contained the original IP (or at least just an IP). But if you called `GetFreePort` then the `Address` was actually an `address:port` combination (due to spec in https://pkg.go.dev/net#Addr)

```
freeport/freeport_test.go:20
            	Error:      	Not equal: 
            	            	expected: "127.0.0.1"
            	            	actual  : "127.0.0.1:55972"
```


